### PR TITLE
Fix require() for Paw 2.2.3: fix #1

### DIFF
--- a/WordPressCodeGenerator.coffee
+++ b/WordPressCodeGenerator.coffee
@@ -1,4 +1,10 @@
-require "mustache.js"
+# in API v0.2.0 and below (Paw 2.2.2 and below), require had no return value
+((root) ->
+  if root.bundle?.minApiVersion('0.2.0')
+    root.Mustache = require("./mustache")
+  else
+    require("mustache.js")
+)(this)
 
 addslashes = (str) ->
     ("#{str}").replace(/[\\']/g, '\\$&')


### PR DESCRIPTION
This fixes the call `require()` for Paw 2.2.3
